### PR TITLE
contractcourt: only halt resolution for TapscriptRoot channels

### DIFF
--- a/contractcourt/htlc_incoming_contest_resolver.go
+++ b/contractcourt/htlc_incoming_contest_resolver.go
@@ -103,7 +103,10 @@ func (h *htlcIncomingContestResolver) Resolve(
 	//
 	// TODO(roasbeef): Implement resolving HTLCs with custom records
 	// (follow-up PR).
-	if len(h.htlc.CustomRecords) != 0 {
+	if len(h.htlc.CustomRecords) != 0 && h.isTapscriptRoot {
+		log.Warnf("Not resolving HTLC with: %v custom records",
+			len(h.htlc.CustomRecords))
+
 		select { //nolint:gosimple
 		case <-h.quit:
 			return nil, errResolverShuttingDown

--- a/contractcourt/htlc_outgoing_contest_resolver.go
+++ b/contractcourt/htlc_outgoing_contest_resolver.go
@@ -62,7 +62,10 @@ func (h *htlcOutgoingContestResolver) Resolve(
 	//
 	// TODO(roasbeef): Implement resolving HTLCs with custom records
 	// (follow-up PR).
-	if len(h.htlc.CustomRecords) != 0 {
+	if len(h.htlc.CustomRecords) != 0 && h.isTapscriptRoot {
+		log.Warnf("Not resolving HTLC with: %v custom records",
+			len(h.htlc.CustomRecords))
+
 		select { //nolint:gosimple
 		case <-h.quit:
 			return nil, errResolverShuttingDown


### PR DESCRIPTION
Opening for itests